### PR TITLE
Addition of function to specify alterative cpuName/crateId/slotNumber

### DIFF
--- a/README.database.md
+++ b/README.database.md
@@ -20,3 +20,17 @@ By default the *MPS_CONFIGURATION_TOP* points to `/afs/slac/g/lcls/physics/mps_c
 ```
 setMpsConfigurationPath(const char* path)
 ```
+
+The values of *CPU_NAME*, *CRATE_ID* and *SLOT_NUMBER* can be overriden by using the function `L2MPSASYNSetApplicationInfo`. The usage of that function is
+
+```
+L2MPSASYNSetApplicationInfo(CpuName, CrateId, SlotNumber)
+```
+
+where:
+
+Parameter  | Description                 | Default parameter  | Value used if default param specified
+-----------|-----------------------------|--------------------|--------------------------------------
+CpuName    | Alternative cpu host name   | "default"          | from `gethostname()` function
+CrateId    | Alternative crate id        | -1                 | from config.yaml
+SlotNumber | Alternative slot number     | -1                 | from config.yaml

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,14 @@
 
 Release notes for the SLAC's LCLS2 HPS MPS EPICS Module.
 
+* 'slot' branch changes:
+  * Add support for changing cpu name/crate id/slot number
+    that allows application to load mps configuration from
+    other locations (see [README.database.md](README.database.md)
+  * Add THR_LOADED PV, which is set by MpsManager after
+    loading thresholds. See [README.thresholds.md](README.thresholds.md)
+    for details.
+
 ## Releases:
 * __R3.0.0__: 2019-07-31 J. Vasquez
   * Update l2Mps to version R3.0.0.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 Release notes for the SLAC's LCLS2 HPS MPS EPICS Module.
 
-* 'slot' branch changes:
+* 'app-info' branch changes:
   * Add support for changing cpu name/crate id/slot number
     that allows application to load mps configuration from
     other locations (see [README.database.md](README.database.md)

--- a/l2MpsAsynApp/Db/Reg1BitRW.template
+++ b/l2MpsAsynApp/Db/Reg1BitRW.template
@@ -1,14 +1,19 @@
 #================================================================================#
 # LCLS-II MPS PV template for 1-bit read-write registers                         #
 # Macro description:                                                             #
-#   - P     : Record name prefix                                                 #
-#   - R     : Record name                                                        #
-#   - DESC  : Description                                                        #
-#   - PORT  : Asyn port name                                                     #
-#   - ADDR  : Asyn parameter list number (0: AppBay0, 1: AppBay1, 2: MpsBase)    #
-#   - PARAM : Asyn parameter name                                                #
-#   - ZNAM  : Label for the "0" state                                            #
-#   - ONAM  : Label for the "1" state                                            #
+#   - P       : Record name prefix                                               #
+#   - R       : Record name                                                      #
+#   - DESC    : Description                                                      #
+#   - PORT    : Asyn port name                                                   #
+#   - ADDR    : Asyn parameter list number (0: AppBay0, 1: AppBay1, 2: MpsBase)  #
+#   - PARAM   : Asyn parameter name                                              #
+#   - ZNAM    : Label for the "0" state                                          #
+#   - ONAM    : Label for the "1" state                                          #
+#   - ASG     : Access security group                                            #
+#   - ZSV     : Alarm for zero state                                             #
+#   - RBV_ZSV : Alarm for zero state                                             #
+#   - DISV    : Disable value (if SDIS has this value record is disabled)        #
+#   - SDIS    : Source of disable value                                          #
 #================================================================================#
 
 record(bo, "$(P):$(R)") {
@@ -19,6 +24,10 @@ record(bo, "$(P):$(R)") {
     field(OUT,  "@asynMask($(PORT),$(ADDR),0x01)$(PARAM)")
     field(ZNAM, "$(ZNAM)")
     field(ONAM, "$(ONAM)")
+    field(ASG,  "$(ASG)")
+    field(ZSV,  "$(ZSV)")
+    field(DISV, "$(DISV)")
+    field(SDIS, "$(SDIS)")
 }
 
 record(bi, "$(P):$(R)_RBV") {
@@ -29,4 +38,6 @@ record(bi, "$(P):$(R)_RBV") {
     field(INP,  "@asynMask($(PORT),$(ADDR),0x01)$(PARAM)")
     field(ZNAM, "$(ZNAM)")
     field(ONAM, "$(ONAM)")
+    field(ASG,  "$(ASG)")
+    field(ZSV,  "$(RBV_ZSV)")
 }

--- a/l2MpsAsynApp/Db/mps.substitutions
+++ b/l2MpsAsynApp/Db/mps.substitutions
@@ -81,12 +81,19 @@ file "RegRW.template" { pattern
 }
 
 file "Reg1BitRW.template" { pattern
-{ R,                DESC,                                       PARAM,          ADDR,   ZNAM,       ONAM       }
-{ MPS_EN,           "MPS Enabled",                              MPS_EN,         "2",    "Disabled", "Enabled"  }
-{ LC1_MODE,         "LCLS operation mode",                      LCLS1_MODE,     "2",    "Disabled", "Enabled"  }
+{ R,                DESC,                                       PARAM,          ADDR,   ZNAM,       ONAM,      ZSV,        RBV_ZSV,    ASG,   DISV, SDIS              }
+{ MPS_EN,           "MPS Enabled",                              MPS_EN,         "2",    "Disabled", "Enabled", "MAJOR",    "MAJOR",    "MCC", 0   , "$(P):THR_LOADED" }
+{ LC1_MODE,         "LCLS operation mode",                      LCLS1_MODE,     "2",    "Disabled", "Enabled", "NO_ALARM", "NO_ALARM", "MCC", 1   , ""                }
 }
 
 file "RegStringRO.template" { pattern
 { R,              DESC,                             PARAM,          ADDR    }
 { APP_TYPE,       "Application type",               APP_TYPE,       "2"     }
 }
+
+file "thr_control.template" { pattern
+{ASG}
+{"MCC"}
+}
+
+

--- a/l2MpsAsynApp/Db/mps_bcm.substitutions
+++ b/l2MpsAsynApp/Db/mps_bcm.substitutions
@@ -13,9 +13,9 @@ file "RegRO.template" { pattern
 
 ### Tables enable PVs ###
 file "Reg1BitRW.template" { pattern
-{ R,                DESC,                                           PARAM,              ADDR,       ZNAM,           ONAM        }
-{ CHARGE_IDL_EN,    "Bay $(BAY) Charge IDLE table enabled",         BCM_IDLEEN_0,       "$(BAY)",   "Disabled",     "Enabled"   }
-{ DIFF_IDL_EN,      "Bay $(BAY) Difference IDLE table enabled",     BCM_IDLEEN_1,       "$(BAY)",   "Disabled",     "Enabled"   }
+{ R,                DESC,                                           PARAM,              ADDR,       ZNAM,           ONAM,      ZSV,        RBV_ZSV,    ASG,   DISV, SDIS }
+{ CHARGE_IDL_EN,    "Bay $(BAY) Charge IDLE table enabled",         BCM_IDLEEN_0,       "$(BAY)",   "Disabled",     "Enabled", "NO_ALARM", "NO_ALARM", "MCC", 1   , ""   }
+{ DIFF_IDL_EN,      "Bay $(BAY) Difference IDLE table enabled",     BCM_IDLEEN_1,       "$(BAY)",   "Disabled",     "Enabled", "NO_ALARM", "NO_ALARM", "MCC", 1   , ""   }
 }
 
 file "Reg1BitRO.template" { pattern

--- a/l2MpsAsynApp/Db/mps_blen.substitutions
+++ b/l2MpsAsynApp/Db/mps_blen.substitutions
@@ -8,8 +8,8 @@ file "RegRO.template" { pattern
 
 ### Tables enable PVs ###
 file "Reg1BitRW.template" { pattern
-{ R,                DESC,                               PARAM,              ADDR,       ZNAM,           ONAM        }
-{ L_IDL_EN,         "Bay $(BAY) IDLE table enabled",    BLEN_IDLEEN_0,      "$(BAY)",   "Disabled",     "Enabled"   }
+{ R,                DESC,                               PARAM,              ADDR,       ZNAM,           ONAM,      ZSV,        RBV_ZSV,    ASG,   DISV, SDIS  }
+{ L_IDL_EN,         "Bay $(BAY) IDLE table enabled",    BLEN_IDLEEN_0,      "$(BAY)",   "Disabled",     "Enabled", "NO_ALARM", "NO_ALARM", "MCC", 1   , ""    }
 }
 
 file "Reg1BitRO.template" { pattern

--- a/l2MpsAsynApp/Db/mps_blm.substitutions
+++ b/l2MpsAsynApp/Db/mps_blm.substitutions
@@ -8,8 +8,8 @@ file "RegRO.template" { pattern
 
 ### Tables enable PVs ###
 file "Reg1BitRW.template" { pattern
-{ R,                DESC,                                               PARAM,                  ADDR,       ZNAM,           ONAM,      }
-{ I0_IDL_EN,        "Bay $(BAY) Ch $(INP) Int 0 IDLE table enabled",    BLM_IDLEEN_$(INP)0,     "$(BAY)",   "Disabled",     "Enabled"  }
+{ R,                DESC,                                               PARAM,                  ADDR,       ZNAM,           ONAM,      ZSV,        RBV_ZSV,    ASG,   DISV, SDIS }
+{ I0_IDL_EN,        "Bay $(BAY) Ch $(INP) Int 0 IDLE table enabled",    BLM_IDLEEN_$(INP)0,     "$(BAY)",   "Disabled",     "Enabled", "NO_ALARM", "NO_ALARM", "MCC", 1   , ""   }
 }
 
 file "Reg1BitRO.template" { pattern

--- a/l2MpsAsynApp/Db/mps_bpm.substitutions
+++ b/l2MpsAsynApp/Db/mps_bpm.substitutions
@@ -16,10 +16,10 @@ file "RegRO.template" { pattern
 
 ### Tables enable PVs ###
 file "Reg1BitRW.template" { pattern
-{ R,            DESC,                               PARAM,              ADDR,       ZNAM,           ONAM        }
-{ X_IDL_EN,     "Bay $(BAY) IDLE table enabled",    BPM_IDLEEN_0,       "$(BAY)",   "Disabled",     "Enabled"   }
-{ Y_IDL_EN,     "Bay $(BAY) IDLE table enabled",    BPM_IDLEEN_1,       "$(BAY)",   "Disabled",     "Enabled"   }
-{ TMIT_IDL_EN,  "Bay $(BAY) IDLE table enabled",    BPM_IDLEEN_2,       "$(BAY)",   "Disabled",     "Enabled"   }
+{ R,            DESC,                               PARAM,              ADDR,       ZNAM,           ONAM,      ZSV,        RBV_ZSV,    ASG,   DISV, SDIS }
+{ X_IDL_EN,     "Bay $(BAY) IDLE table enabled",    BPM_IDLEEN_0,       "$(BAY)",   "Disabled",     "Enabled", "NO_ALARM", "NO_ALARM", "MCC", 1   , ""   }
+{ Y_IDL_EN,     "Bay $(BAY) IDLE table enabled",    BPM_IDLEEN_1,       "$(BAY)",   "Disabled",     "Enabled", "NO_ALARM", "NO_ALARM", "MCC", 1   , ""   }
+{ TMIT_IDL_EN,  "Bay $(BAY) IDLE table enabled",    BPM_IDLEEN_2,       "$(BAY)",   "Disabled",     "Enabled", "NO_ALARM", "NO_ALARM", "MCC", 1   , ""   }
 }
 
 file "Reg1BitRO.template" { pattern

--- a/l2MpsAsynApp/Db/thr_control.template
+++ b/l2MpsAsynApp/Db/thr_control.template
@@ -1,0 +1,16 @@
+#================================================================================#
+# LCLS-II MPS PV template for MpsManager threshold control                       #
+# Macro description:                                                             #
+#   - P       : Record name prefix                                               #
+#   - ASG     : Access security group                                            #
+#================================================================================#
+record(bo, "$(P):THR_LOADED") {
+    field(DESC, "Set by MpsManager after IOC reboots")
+    field(PINI, "YES")
+    field(VAL,  "0")
+    field(ZNAM, "Not loaded")
+    field(ONAM, "Loaded")
+    field(ASG,  "$(ASG)")
+    field(ZSV,  "MAJOR")
+}
+

--- a/l2MpsAsynApp/src/Makefile
+++ b/l2MpsAsynApp/src/Makefile
@@ -13,7 +13,7 @@ DBD += l2MpsAsyn.dbd
 INC += drvL2MPSASYN.h
 
 LIBRARY_IOC += l2MpsAsyn
-LIB_SRCS += initHooks.c mpsManagerInfo.c thresholds.c drvL2MPSASYN.cpp
+LIB_SRCS += initHooks.c mpsManagerInfo.c mpsApplicationInfo.c thresholds.c drvL2MPSASYN.cpp
 LIB_LIBS += asyn
 LIB_LIBS += yamlLoader
 

--- a/l2MpsAsynApp/src/drvL2MPSASYN.h
+++ b/l2MpsAsynApp/src/drvL2MPSASYN.h
@@ -39,6 +39,7 @@
 
 extern "C" {
     #include "mpsManagerInfo.h"
+    #include "mpsApplicationInfo.h"
 }
 
 #define DRIVER_NAME         "L2MPS"
@@ -256,7 +257,7 @@ class L2MPS : public asynPortDriver {
         void updateAppParameters(int bay, T data);
 
         // Default parameters, which can be changed from the IOC shell
-        static std::string mpsConfigrationPath;     // Default location of the MPS configuration
+        static std::string mpsConfigurationPath;     // Default location of the MPS configuration
 
     private:
         const char *driverName_;               // This driver name

--- a/l2MpsAsynApp/src/l2MpsAsynInclude.dbd
+++ b/l2MpsAsynApp/src/l2MpsAsynInclude.dbd
@@ -1,3 +1,4 @@
 registrar(drvL2MPSASYNRegister)
 registrar(l2MpsAsynInitHooksRegister)
 registrar(setMpsManagerRegister)
+registrar(setMpsApplicationInfoRegister)

--- a/l2MpsAsynApp/src/mpsApplicationInfo.c
+++ b/l2MpsAsynApp/src/mpsApplicationInfo.c
@@ -1,0 +1,65 @@
+#include "mpsApplicationInfo.h"
+
+// Information used to override defaults read from hostname(),
+// and the FW configuration. These are used for testing purposes only.
+char* mpsCpuName    = MPS_USE_DEFAULT_CPU_NAME;
+int   mpsCrateId    = MPS_USE_DEFAULT_CRATE_ID;
+int   mpsSlotNumber = MPS_USE_DEFAULT_SLOT_NUMBER;
+
+int setMpsApplicationInfo(const char* cpuName, int crateId, int slotNumber)
+{
+  printf("Setting application crate id to: '%d'\n", crateId);
+  mpsCrateId = crateId;
+
+  printf("Setting application slot number to: '%d'\n", slotNumber);
+  mpsSlotNumber = slotNumber;
+
+  if ( ( ! cpuName ) || ( cpuName[0] == '\0' ) )
+    {
+      fprintf( stderr, "Error: specified cpuName for application is empty. Ignoring it.\n" );
+    }
+  else
+    {
+      printf("Setting application cpuName to: '%s'.\n", cpuName);
+      mpsCpuName = (char*) malloc( strlen(cpuName) * sizeof(char) );
+      strcpy(mpsCpuName, cpuName);
+    }
+
+  return 0;
+}
+
+void getMpsApplicationInfo(char** cpuName, int* crateId, int* slotNumber)
+{
+    *cpuName = (char*) malloc( strlen(mpsCpuName) * sizeof(char) );
+    strcpy(*cpuName, mpsCpuName);
+    *crateId = mpsCrateId;
+    *slotNumber = mpsSlotNumber;
+}
+
+
+/* The setMpsApplication* functions are exposed to the IOC shell
+   so that the user can call it from st.cmd */
+static const iocshArg setMpsApplicationInfoArgs0 = { "MpsApplicationInfoCpuName",    iocshArgString };
+static const iocshArg setMpsApplicationInfoArgs1 = { "MpsApplicationInfoCrateId",    iocshArgInt    };
+static const iocshArg setMpsApplicationInfoArgs2 = { "MpsApplicationInfoSlotNumber", iocshArgInt    };
+
+static const iocshArg * const setMpsApplicationInfoArgs[] =
+{
+  &setMpsApplicationInfoArgs0,
+  &setMpsApplicationInfoArgs1,
+  &setMpsApplicationInfoArgs2
+};
+ 
+static const iocshFuncDef setMpsApplicationInfoFuncDef = { "L2MPSASYNSetApplicationInfo", 3, setMpsApplicationInfoArgs };
+
+static void setMpsApplicationInfoCallFunc(const iocshArgBuf *args)
+{
+  setMpsApplicationInfo(args[0].sval, args[1].ival, args[2].ival);
+}
+
+void setMpsApplicationInfoRegister(void)
+{
+   iocshRegister(&setMpsApplicationInfoFuncDef, setMpsApplicationInfoCallFunc);
+}
+
+epicsExportRegistrar(setMpsApplicationInfoRegister);

--- a/l2MpsAsynApp/src/mpsApplicationInfo.h
+++ b/l2MpsAsynApp/src/mpsApplicationInfo.h
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <epicsPrint.h>
+#include <iocsh.h>
+#include <epicsExport.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+
+#define MPS_USE_DEFAULT_CPU_NAME    "default"
+#define MPS_USE_DEFAULT_CRATE_ID    -1
+#define MPS_USE_DEFAULT_SLOT_NUMBER -1
+
+// This function is used change the default CPU name, slot number and crate id
+// that is used to locate the MPS database generated information
+int setMpsApplicationInfo(const char* cpuName, int crateId, int slotNumber);
+
+// This function is used to get the information needed to contact the
+// MPS Manager.
+void getMpsApplicationInfo(char** cpuName, int* crateId, int* slotNumber);


### PR DESCRIPTION
  * Add support for changing cpu name/crate id/slot number
    that allows application to load mps configuration from
    other locations (see [README.database.md](README.database.md)
  * Add THR_LOADED PV, which is set by MpsManager after
    loading thresholds. See [README.thresholds.md](README.thresholds.md)
    for details.
