### PR TITLE
Update BPM TMIT thresholds

### DIFF
--- a/README.scaleFactor.md
+++ b/README.scaleFactor.md
@@ -2,7 +2,7 @@
 
 Threshold are applied in firmware in raw units (ADC counts for example). But the threshold PVs can represent engineering units is a scale factor is provided by the application.
 
-The MPS application has two PVs called **`$(APP_PREFIX):$(PROPERTY)_SS`**  amd **`$(APP_PREFIX):$(PROPERTY)_SO`** which read the scale slope and offset value, respectively, from tow PVs provided by the application. The MPS PVs read the values from the application PVs and the values to the low level driver where the scaling is applied. Readback values are also provided in the PVs **`$(APP_PREFIX):$(PROPERTY)_SS_RBV`** and **`$(APP_PREFIX):$(PROPERTY)_SO_RBV`** respectively.
+The MPS application has two PVs called **`$(APP_PREFIX):$(PROPERTY)_SS`**  and **`$(APP_PREFIX):$(PROPERTY)_SO`** which read the scale slope and offset value, respectively, from tow PVs provided by the application. The MPS PVs read the values from the application PVs and the values to the low level driver where the scaling is applied. Readback values are also provided in the PVs **`$(APP_PREFIX):$(PROPERTY)_SS_RBV`** and **`$(APP_PREFIX):$(PROPERTY)_SO_RBV`** respectively.
 
 The name of application PVs are **`$(APP_PREFIX):$(PROPERTY)_FWSLO`**  for the slope value, and **`$(APP_PREFIX):$(PROPERTY)_FWOFF`** for the offset value. BPM applications is an exception to this rule; it only provides a slope value PV named **`$(APP_PREFIX):$(PROPERTY)_FWSCL`**.
 
@@ -28,9 +28,9 @@ BPM applications can provide, for example:
 
 **`$(APP_PREFIX):X_FWSCL`** [mm/raw]
 **`$(APP_PREFIX):Y_FWSCL`** [mm/raw]
-**`$(APP_PREFIX):TMIT_FWSCL`** [Nel/raw]
+**`$(APP_PREFIX):CHRG_FWSCL`** [pC/raw]
 
-Then the threshold for **X** and **Y** will be expressed in **mm**, and the thresholds for **TMIT** will be expressed in **Nel**.
+Then the threshold for **X** and **Y** will be expressed in **mm**, and the thresholds for **CHRG** will be expressed in **pC**.
 
 A BLM application, on the other hand, used to read a solenoid device, can provide, for example:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,11 @@
 Release notes for the SLAC's LCLS2 HPS MPS EPICS Module.
 
 ## Releases:
+
+  * Update BPM TMIT threshold. BPMs now use TMIT difference, expressed in `pC`. So, for the TMIT
+    threshold related PVs rename the PVs, replacing `TMIT` with `CHRG`, change units from `Nel`
+    to `pC`, and change the scale factor PV from `$(P):TMIT_FWSCL` to `$(P):CHRG_FWSCL`.
+
 * __R3.5.0__: 2021-02-05 J. Vasquez
   * Update l2Mps to version R3.5.0.
   * Add support for the new Digital Link Node. The new type is `MPS_DN`.

--- a/l2MpsAsynApp/Db/mps_bpm.substitutions
+++ b/l2MpsAsynApp/Db/mps_bpm.substitutions
@@ -3,15 +3,15 @@ file "RegRO.template" { pattern
 { R,                DESC,                               PARAM,              ADDR        }
 { X_THR_CH,         "Bay $(BAY) X Threshold channel",   BPM_THRNUM_0,       "$(BAY)"    }
 { Y_THR_CH,         "Bay $(BAY) Y Threshold channel",   BPM_THRNUM_1,       "$(BAY)"    }
-{ TMIT_THR_CH,      "Bay $(BAY) C Threshold channel",   BPM_THRNUM_2,       "$(BAY)"    }
+{ CHRG_THR_CH,      "Bay $(BAY) C Threshold channel",   BPM_THRNUM_2,       "$(BAY)"    }
 
 { X_THR_CNT,        "Bay $(BAY) X Threshold count",     BPM_THRCNT_0,       "$(BAY)"    }
 { Y_THR_CNT,        "Bay $(BAY) Y Threshold count",     BPM_THRCNT_1,       "$(BAY)"    }
-{ TMIT_THR_CNT,     "Bay $(BAY) C Threshold count",     BPM_THRCNT_2,       "$(BAY)"    }
+{ CHRG_THR_CNT,     "Bay $(BAY) C Threshold count",     BPM_THRCNT_2,       "$(BAY)"    }
 
 { X_THR_BYTEMAP,    "Bay $(BAY) X Threshold byte map",  BPM_BYTEMAP_0,      "$(BAY)"    }
 { Y_THR_BYTEMAP,    "Bay $(BAY) Y Threshold byte map",  BPM_BYTEMAP_1,      "$(BAY)"    }
-{ TMIT_THR_BYTEMAP, "Bay $(BAY) C Threshold byte map",  BPM_BYTEMAP_2,      "$(BAY)"    }
+{ CHRG_THR_BYTEMAP, "Bay $(BAY) C Threshold byte map",  BPM_BYTEMAP_2,      "$(BAY)"    }
 }
 
 ### Tables enable PVs ###
@@ -19,18 +19,18 @@ file "Reg1BitRW.template" { pattern
 { R,            DESC,                               PARAM,              ADDR,       ZNAM,           ONAM        }
 { X_IDL_EN,     "Bay $(BAY) IDLE table enabled",    BPM_IDLEEN_0,       "$(BAY)",   "Disabled",     "Enabled"   }
 { Y_IDL_EN,     "Bay $(BAY) IDLE table enabled",    BPM_IDLEEN_1,       "$(BAY)",   "Disabled",     "Enabled"   }
-{ TMIT_IDL_EN,  "Bay $(BAY) IDLE table enabled",    BPM_IDLEEN_2,       "$(BAY)",   "Disabled",     "Enabled"   }
+{ CHRG_IDL_EN,  "Bay $(BAY) IDLE table enabled",    BPM_IDLEEN_2,       "$(BAY)",   "Disabled",     "Enabled"   }
 }
 
 file "Reg1BitRO.template" { pattern
 { R,            DESC,                               PARAM,              ADDR,       ZNAM,           ONAM        }
 { X_ALT_EN,     "Bay $(BAY) ALT table enabled",     BPM_ALTEN_0,        "$(BAY)",   "Disabled",     "Enabled"   }
 { Y_ALT_EN,     "Bay $(BAY) ALT table enabled",     BPM_ALTEN_1,        "$(BAY)",   "Disabled",     "Enabled"   }
-{ TMIT_ALT_EN,  "Bay $(BAY) ALT table enabled",     BPM_ALTEN_2,        "$(BAY)",   "Disabled",     "Enabled"   }
+{ CHRG_ALT_EN,  "Bay $(BAY) ALT table enabled",     BPM_ALTEN_2,        "$(BAY)",   "Disabled",     "Enabled"   }
 
 { X_LC1_EN,     "Bay $(BAY) LCLS1 table enabled",   BPM_LCLS1EN_0,      "$(BAY)",   "Disabled",     "Enabled"   }
 { Y_LC1_EN,     "Bay $(BAY) LCLS1 table enabled",   BPM_LCLS1EN_1,      "$(BAY)",   "Disabled",     "Enabled"   }
-{ TMIT_LC1_EN,  "Bay $(BAY) LCLS1 table enabled",   BPM_LCLS1EN_2,      "$(BAY)",   "Disabled",     "Enabled"   }
+{ CHRG_LC1_EN,  "Bay $(BAY) LCLS1 table enabled",   BPM_LCLS1EN_2,      "$(BAY)",   "Disabled",     "Enabled"   }
 }
 
 ### Threshold PVs ###
@@ -38,11 +38,11 @@ file "thr.template" { pattern
 { R,            DESC,                                       APP,    EGU,    PREC,   CH,     TABLE,  THR,    }
 { X_T0_LC1,     "BPM, Bay $(BAY), X, LCLS1, Threshold",     "BPM",  "mm",   "2",    "0",    "0",    "0",    }
 { Y_T0_LC1,     "BPM, Bay $(BAY), Y, LCLS1, Threshold",     "BPM",  "mm",   "2",    "1",    "0",    "0",    }
-{ TMIT_T0_LC1,  "BPM, Bay $(BAY), C, LCLS1, Threshold",     "BPM",  "Nel",  "2",    "2",    "0",    "0",    }
+{ CHRG_T0_LC1,  "BPM, Bay $(BAY), C, LCLS1, Threshold",     "BPM",  "pC",   "2",    "2",    "0",    "0",    }
 
 { X_T0_IDL,     "BPM, Bay $(BAY), X, IDLE, Threshold",      "BPM",  "mm",   "2",    "0",    "1",    "0",    }
 { Y_T0_IDL,     "BPM, Bay $(BAY), Y, IDLE, Threshold",      "BPM",  "mm",   "2",    "1",    "1",    "0",    }
-{ TMIT_T0_IDL,  "BPM, Bay $(BAY), C, IDLE, Threshold",      "BPM",  "Nel",  "2",    "2",    "1",    "0",    }
+{ CHRG_T0_IDL,  "BPM, Bay $(BAY), C, IDLE, Threshold",      "BPM",  "pC",   "2",    "2",    "1",    "0",    }
 
 { X_T0,         "BPM, Bay $(BAY), X, STD, Threshold 0",     "BPM",  "mm",   "2",    "0",    "2",    "0",    }
 { X_T1,         "BPM, Bay $(BAY), X, STD, Threshold 1",     "BPM",  "mm",   "2",    "0",    "2",    "1",    }
@@ -60,14 +60,14 @@ file "thr.template" { pattern
 { Y_T5,         "BPM, Bay $(BAY), Y, STD, Threshold 5",     "BPM",  "mm",   "2",    "1",    "2",    "5",    }
 { Y_T6,         "BPM, Bay $(BAY), Y, STD, Threshold 6",     "BPM",  "mm",   "2",    "1",    "2",    "6",    }
 { Y_T7,         "BPM, Bay $(BAY), Y, STD, Threshold 7",     "BPM",  "mm",   "2",    "1",    "2",    "7",    }
-{ TMIT_T0,      "BPM, Bay $(BAY), C, STD, Threshold 0",     "BPM",  "Nel",  "2",    "2",    "2",    "0",    }
-{ TMIT_T1,      "BPM, Bay $(BAY), C, STD, Threshold 1",     "BPM",  "Nel",  "2",    "2",    "2",    "1",    }
-{ TMIT_T2,      "BPM, Bay $(BAY), C, STD, Threshold 2",     "BPM",  "Nel",  "2",    "2",    "2",    "2",    }
-{ TMIT_T3,      "BPM, Bay $(BAY), C, STD, Threshold 3",     "BPM",  "Nel",  "2",    "2",    "2",    "3",    }
-{ TMIT_T4,      "BPM, Bay $(BAY), C, STD, Threshold 4",     "BPM",  "Nel",  "2",    "2",    "2",    "4",    }
-{ TMIT_T5,      "BPM, Bay $(BAY), C, STD, Threshold 5",     "BPM",  "Nel",  "2",    "2",    "2",    "5",    }
-{ TMIT_T6,      "BPM, Bay $(BAY), C, STD, Threshold 6",     "BPM",  "Nel",  "2",    "2",    "2",    "6",    }
-{ TMIT_T7,      "BPM, Bay $(BAY), C, STD, Threshold 7",     "BPM",  "Nel",  "2",    "2",    "2",    "7",    }
+{ CHRG_T0,      "BPM, Bay $(BAY), C, STD, Threshold 0",     "BPM",  "pC",   "2",    "2",    "2",    "0",    }
+{ CHRG_T1,      "BPM, Bay $(BAY), C, STD, Threshold 1",     "BPM",  "pC",   "2",    "2",    "2",    "1",    }
+{ CHRG_T2,      "BPM, Bay $(BAY), C, STD, Threshold 2",     "BPM",  "pC",   "2",    "2",    "2",    "2",    }
+{ CHRG_T3,      "BPM, Bay $(BAY), C, STD, Threshold 3",     "BPM",  "pC",   "2",    "2",    "2",    "3",    }
+{ CHRG_T4,      "BPM, Bay $(BAY), C, STD, Threshold 4",     "BPM",  "pC",   "2",    "2",    "2",    "4",    }
+{ CHRG_T5,      "BPM, Bay $(BAY), C, STD, Threshold 5",     "BPM",  "pC",   "2",    "2",    "2",    "5",    }
+{ CHRG_T6,      "BPM, Bay $(BAY), C, STD, Threshold 6",     "BPM",  "pC",   "2",    "2",    "2",    "6",    }
+{ CHRG_T7,      "BPM, Bay $(BAY), C, STD, Threshold 7",     "BPM",  "pC",   "2",    "2",    "2",    "7",    }
 
 { X_T0_ALT,     "BPM, Bay $(BAY), X, ALT, Threshold 0",     "BPM",  "mm",   "2",    "0",    "3",    "0",    }
 { X_T1_ALT,     "BPM, Bay $(BAY), X, ALT, Threshold 1",     "BPM",  "mm",   "2",    "0",    "3",    "1",    }
@@ -85,14 +85,14 @@ file "thr.template" { pattern
 { Y_T5_ALT,     "BPM, Bay $(BAY), Y, ALT, Threshold 5",     "BPM",  "mm",   "2",    "1",    "3",    "5",    }
 { Y_T6_ALT,     "BPM, Bay $(BAY), Y, ALT, Threshold 6",     "BPM",  "mm",   "2",    "1",    "3",    "6",    }
 { Y_T7_ALT,     "BPM, Bay $(BAY), Y, ALT, Threshold 7",     "BPM",  "mm",   "2",    "1",    "3",    "7",    }
-{ TMIT_T0_ALT,  "BPM, Bay $(BAY), C, ALT, Threshold 0",     "BPM",  "Nel",  "2",    "2",    "3",    "0",    }
-{ TMIT_T1_ALT,  "BPM, Bay $(BAY), C, ALT, Threshold 1",     "BPM",  "Nel",  "2",    "2",    "3",    "1",    }
-{ TMIT_T2_ALT,  "BPM, Bay $(BAY), C, ALT, Threshold 2",     "BPM",  "Nel",  "2",    "2",    "3",    "2",    }
-{ TMIT_T3_ALT,  "BPM, Bay $(BAY), C, ALT, Threshold 3",     "BPM",  "Nel",  "2",    "2",    "3",    "3",    }
-{ TMIT_T4_ALT,  "BPM, Bay $(BAY), C, ALT, Threshold 4",     "BPM",  "Nel",  "2",    "2",    "3",    "4",    }
-{ TMIT_T5_ALT,  "BPM, Bay $(BAY), C, ALT, Threshold 5",     "BPM",  "Nel",  "2",    "2",    "3",    "5",    }
-{ TMIT_T6_ALT,  "BPM, Bay $(BAY), C, ALT, Threshold 6",     "BPM",  "Nel",  "2",    "2",    "3",    "6",    }
-{ TMIT_T7_ALT,  "BPM, Bay $(BAY), C, ALT, Threshold 7",     "BPM",  "Nel",  "2",    "2",    "3",    "7",    }
+{ CHRG_T0_ALT,  "BPM, Bay $(BAY), C, ALT, Threshold 0",     "BPM",  "pC",   "2",    "2",    "3",    "0",    }
+{ CHRG_T1_ALT,  "BPM, Bay $(BAY), C, ALT, Threshold 1",     "BPM",  "pC",   "2",    "2",    "3",    "1",    }
+{ CHRG_T2_ALT,  "BPM, Bay $(BAY), C, ALT, Threshold 2",     "BPM",  "pC",   "2",    "2",    "3",    "2",    }
+{ CHRG_T3_ALT,  "BPM, Bay $(BAY), C, ALT, Threshold 3",     "BPM",  "pC",   "2",    "2",    "3",    "3",    }
+{ CHRG_T4_ALT,  "BPM, Bay $(BAY), C, ALT, Threshold 4",     "BPM",  "pC",   "2",    "2",    "3",    "4",    }
+{ CHRG_T5_ALT,  "BPM, Bay $(BAY), C, ALT, Threshold 5",     "BPM",  "pC",   "2",    "2",    "3",    "5",    }
+{ CHRG_T6_ALT,  "BPM, Bay $(BAY), C, ALT, Threshold 6",     "BPM",  "pC",   "2",    "2",    "3",    "6",    }
+{ CHRG_T7_ALT,  "BPM, Bay $(BAY), C, ALT, Threshold 7",     "BPM",  "pC",   "2",    "2",    "3",    "7",    }
 }
 
 ### Scale PVs ###
@@ -100,5 +100,5 @@ file "scale.template" { pattern
 { R,        DESC,                           APP,        EGU,    PREC,   CH,     SCALE_SLOPE_PV,     SCALE_OFFSET_PV,    SCAN        }
 { X,        "Bay $(BAY) X Scale factor",    "BPM",      "mm",   "4",    "0",    "$(P):X_FWSCL",     "",                 "1 second"  }
 { Y,        "Bay $(BAY) Y Scale factor",    "BPM",      "mm",   "4",    "1",    "$(P):Y_FWSCL",     "",                 "1 second"  }
-{ TMIT,     "Bay $(BAY) C Scale factor",    "BPM",      "Nel",  "4",    "2",    "$(P):TMIT_FWSCL",  "",                 "1 second"  }
+{ CHRG,     "Bay $(BAY) C Scale factor",    "BPM",      "pC",   "4",    "2",    "$(P):CHRG_FWSCL",  "",                 "1 second"  }
 }


### PR DESCRIPTION
BPMs now use TMIT difference, expressed in `pC`. So, for the TMIT threshold related PVs:
- Rename the PVs, replacing `TMIT` with `CHRG`,
- Change units from `Nel` to `pC`, and 
- Change the scale factor PV from `$(P):TMIT_FWSCL` to `$(P):CHRG_FWSCL`.

https://jira.slac.stanford.edu/browse/ESLMPS-101